### PR TITLE
update semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "author": "ston3o",
   "license": "MIT",
   "engines": {
-      "node": "6.11.2",
-      "npm": "3.10.10"
+      "node": "~6.11",
+      "npm": "~3.10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
```
> $ yarn global add netclix                                                                                ⬡ 7.10.0 [±master ●●]
yarn global v0.27.5
warning package.json: No license field
warning No license field
[1/4] Resolving packages...
[2/4] Fetching packages...
error netclix@0.2.6: The engine "node" is incompatible with this module. Expected version "6.11.2".
error Found incompatible module
```

using node 7